### PR TITLE
Updating README to include the right vcs import cmd for av submodules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Ignore AV modules
+src/
+
+# Visual Studio Code
+.vscode/

--- a/README.md
+++ b/README.md
@@ -9,4 +9,10 @@ To clone all relevant repos:
 2. Install vcstool (After ROS is sourced): 
 `sudo apt update && sudo apt install python3-vcstool`
 3. Then, from the tartan_carpet repo, run: 
-`vcs import --input av.repos ../`
+
+```bash
+    # Crate src directory
+    mkdir src
+    # Import AV repos and submodules
+    vcs import --recursive --input av.repos ./src
+```


### PR DESCRIPTION
This PR fixes #1

It now instructs to add `--recursive` flag when pulling repos with `vcs import` to also pull submodules.

Also, all the repos are cloned inside the `src` directory which is git ignored.

