### PR TITLE
Upgrade `av_velodyne` docker version

### DIFF
--- a/sensors_compose.yaml
+++ b/sensors_compose.yaml
@@ -61,7 +61,7 @@ services:
       - "/etc/localtime:/etc/localtime:ro"
 
   av_velodyne:
-    image: "ghcr.io/ipab-rad/av_velodyne:1.3.0"
+    image: "ghcr.io/ipab-rad/av_velodyne:2.0.0"
     container_name: av_velodyne
     network_mode: "host"
     privileged: true


### PR DESCRIPTION
- Upgrade from `1.3.0` to `2.0.0`
  - This new docker contains a tier4's [nebula](https://github.com/tier4/nebula) velodyne driver to publish a  point cloud compatible with Autoware