### PR TITLE
Replace pre-commit.ci with github workflows

### DIFF
--- a/.github/workflows/ci-pre-commit.yml
+++ b/.github/workflows/ci-pre-commit.yml
@@ -1,0 +1,11 @@
+name: Pre-commit
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  pre-commit:
+    uses: ./.github/workflows/reusable-pre-commit.yml
+    with:
+      ros_distro: humble

--- a/.github/workflows/reusable-pre-commit.yml
+++ b/.github/workflows/reusable-pre-commit.yml
@@ -1,0 +1,75 @@
+name: Reusable pre-commit
+# The pre-commit configuration is in .pre-commit-config.yaml
+# OG author: Christoph Fröhlich <christoph.froehlich@ait.ac.at>[ROS2 Control CI]
+# UoE editor: Alejandro Bordallo <alex.bordallo@ed.ac.uk>
+
+on:
+  workflow_call:
+    inputs:
+      ros_distro:
+        description: 'ROS2 distribution name'
+        required: true
+        type: string
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    container: ros:${{ inputs.ros_distro }}
+    env:
+      # this will be src/{repo-owner}/{repo-name}
+      path: src/${{ github.repository }}
+    steps:
+      - name: "Determine prerequisites"
+        id: prereq
+        run: |
+          command -v sudo >/dev/null 2>&1 || (apt update && apt install -y sudo)
+          sudo apt update
+          echo "need_node=$(command -v node >/dev/null 2>&1 && echo 0 || echo 1)" >> $GITHUB_OUTPUT
+          echo "need_ros2=$(if [ -d "/opt/ros/${{ inputs.ros_distro }}" ]; then echo 0; else echo 1; fi)" \
+          >> $GITHUB_OUTPUT
+
+      # needed for github actions, and only if a bare ubuntu image is used
+      - uses: actions/setup-node@v4
+        if: ${{ steps.prereq.outputs.need_node == '1' && !env.ACT }}
+      - name: Install node
+        # Consider switching to https://github.com/actions/setup-node when it works
+        # https://github.com/nektos/act/issues/973
+        if: ${{ steps.prereq.outputs.need_node == '1' && env.ACT }}
+        run: |
+          sudo apt install -y curl
+          curl -sS https://webi.sh/node | sh
+          echo ~/.local/opt/node/bin >> $GITHUB_PATH
+
+      # needed only if a non-ros image is used
+      - uses: ros-tooling/setup-ros@0.7.10
+        if: ${{ steps.prereq.outputs.need_ros2 == '1' }}
+        with:
+          use-ros2-testing: true
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          path: ${{ env.path }}
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit|${{ inputs.ros_distro }}|${{ hashFiles( format('{0}/.pre-commit-config.yaml', env.path) ) }}
+      - name: Install pre-commit and system hooks
+        shell: bash
+        run: |
+          sudo apt-get install -qq \
+          ros-${{ inputs.ros_distro }}-ament-cppcheck \
+          ros-${{ inputs.ros_distro }}-ament-cpplint \
+          ros-${{ inputs.ros_distro }}-ament-lint-cmake \
+          ros-${{ inputs.ros_distro }}-ament-copyright \
+          python3-venv
+          python3 -m venv .venv
+          source .venv/bin/activate
+          python3 -m pip install pre-commit
+      - name: Run pre-commit
+        shell: bash
+        run: |
+          source .venv/bin/activate
+          source /opt/ros/${{ inputs.ros_distro }}/setup.bash
+          cd ${{ env.path }}
+          pre-commit run --show-diff-on-failure --color=always --all-files --hook-stage manual

--- a/.github/workflows/reusable-update-pre-commit.yml
+++ b/.github/workflows/reusable-update-pre-commit.yml
@@ -1,0 +1,111 @@
+name: Reusable Update pre-commit
+# Update pre-commit config and create PR if changes are detected
+# OG author: Christoph Fröhlich <christoph.froehlich@ait.ac.at>[ROS2 Control CI]
+# UoE editor: Alejandro Bordallo <alex.bordallo@ed.ac.uk>
+
+on:
+  workflow_call:
+    inputs:
+      ref_for_scheduled_build:
+        description: |
+          'Reference on which the repo should be checkout for scheduled build.
+          Usually is this name of a branch or a tag.'
+        default: ''
+        required: false
+        type: string
+    secrets:
+      precommit-pr-token:
+        description: 'PAT from GreatAlexander for PR auto-approval'
+        required: true
+
+jobs:
+  auto_update_and_create_pr:
+    runs-on: ubuntu-latest
+    env:
+      # this will be src/{repo-owner}/{repo-name}
+      path: src/${{ github.repository }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          path: ${{ env.path }}
+          ref: ${{ github.event.inputs.ref_for_scheduled_build }}
+
+      - name: Install pre-commit
+        run: |
+          sudo apt-get install -qq python3-venv
+          python3 -m venv .venv
+          source .venv/bin/activate
+          python3 -m pip install pre-commit
+
+      - name: Auto-update with pre-commit
+        run: |
+          source .venv/bin/activate
+          cd ${{ env.path }}
+          pre-commit autoupdate || true  # Ignoring errors
+
+      - name: Check for changes
+        id: git_status
+        run: |
+          cd ${{ env.path }}
+          git diff --quiet && echo "changed=false" >> $GITHUB_OUTPUT || echo "changed=true" >> $GITHUB_OUTPUT
+
+      - name: There are changes
+        id: git_diff
+        if: steps.git_status.outputs.changed == 'true'
+        run: |
+          cd ${{ env.path }}
+          {
+            echo 'PR_COMMIT_DIFF<<EOF'
+            git diff --unified=1
+            echo EOF
+          } >> "$GITHUB_ENV"
+          git diff --exit-code || true
+
+      - name: No changes!
+        if: steps.git_status.outputs.changed == 'false'
+        run: |
+          echo "No changes detected"
+
+      - name: Create Pull Request
+        id: cpr
+        if: steps.git_status.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: auto-update-${{ github.event.inputs.ref_for_scheduled_build }}
+          base: main
+          commit-message: |
+            Bump version of pre-commit hooks
+
+            ```diff
+            ${{ env.PR_COMMIT_DIFF }}
+            ```
+          title: Bump version of pre-commit hooks
+          body: |
+            This pull request contains auto-updated files of the pre-commit config.
+
+            ```diff
+            ${{ env.PR_COMMIT_DIFF }}
+            ```
+          delete-branch: true
+          draft: false
+          path: ${{ env.path }}
+
+      - name: Enable Pull Request Automerge
+        if: steps.cpr.outputs.pull-request-operation == 'created'
+        run: |
+          cd ${{ env.path }}
+          gh pr merge --squash --auto "${{ steps.cpr.outputs.pull-request-number }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Auto approve
+        if: steps.cpr.outputs.pull-request-operation == 'created'
+        run: |
+          cd ${{ env.path }}
+          gh pr review --approve "${{ steps.cpr.outputs.pull-request-number }}"
+        env:
+          GH_TOKEN: ${{ secrets.precommit-pr-token }}

--- a/.github/workflows/update-pre-commit.yml
+++ b/.github/workflows/update-pre-commit.yml
@@ -1,0 +1,15 @@
+name: Auto Update pre-commit
+# Update pre-commit config and create PR if changes are detected
+# OG author: Christoph Fröhlich <christoph.froehlich@ait.ac.at>[ROS2 Control CI]
+# UoE editor: Alejandro Bordallo <alex.bordallo@ed.ac.uk>
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 2 * *'  # Runs at 00:00, on day 2 of the month
+
+jobs:
+  auto_update_and_create_pr:
+    uses: ./.github/workflows/reusable-update-pre-commit.yml
+    secrets:
+      precommit-pr-token: ${{ secrets.PRECOMMIT_AUTOUPDATE_PR_TOKEN }}

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -14,19 +14,3 @@ pull_request_rules:
         users:
           - GreatAlexander
           - hect95
-  - name: automatic merge for pre-commit ci updates
-    conditions:
-      - author=pre-commit-ci[bot]
-      - title=[pre-commit.ci] pre-commit autoupdate
-    actions:
-      merge:
-        method: squash
-merge_protections:
-  - name: Require approval
-    description: Require at least one review approval before merging is allowed (If
-      not a pre-commit PR)
-    if:
-      - -author = pre-commit-ci[bot]
-      - base = main
-    success_conditions:
-      - "#approved-reviews-by >= 1"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -152,15 +152,3 @@ repos:
     hooks:
       - id: hadolint
         args: ['--ignore=DL3008']
-
-ci:
-  autofix_commit_msg: |
-      [pre-commit.ci] auto fixes from pre-commit.com hooks
-
-      for more information, see https://pre-commit.ci
-  autofix_prs: false
-  autoupdate_branch: ''
-  autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
-  autoupdate_schedule: monthly
-  skip: [ament_cppcheck, ament_cpplint, ament_lint_cmake]
-  submodules: false


### PR DESCRIPTION
 - More maintainable and less overbearing than pre-commit.ci
 - Runs pre-commit on every pull-request based on config
 - Updates pre-commit hook versions periodically (2nd day of the month)
 - Remove ci params from pre-commit config
 - No automatic merging by mergify, it's now done by github
 - No merge_protections by mergify, it's now done by github